### PR TITLE
fix(rtorrent): set default network.xmlrpc.size_limit to 8m

### DIFF
--- a/rtorrent/rtorrent.rc
+++ b/rtorrent/rtorrent.rc
@@ -57,7 +57,7 @@ network.max_open_sockets.set = 300
 ## Memory resource usage (increase if you have a large number of items loaded,
 ## and/or the available resources to spend)
 pieces.memory.max.set = 1800M
-# network.xmlrpc.size_limit.set = 4M
+network.xmlrpc.size_limit.set = 8M
 
 
 ## Basic operational settings (no need to change these)


### PR DESCRIPTION
This resolves "XML-RPC request too large" errors when adding unusually large .torrent files.

The bugfix only applies to newly generated copies of rtorrent.rc, which are typically created the first time the Docker container is started. To apply this fix, you can either delete the existing rtorrent.rc file to allow the image to generate a new configuration with the fix included or manually edit the rtorrent.rc file to apply the changes yourself.

Fixes #30