### PR TITLE
fix(rtorrent): fix compatibility between flood:4.9.5 and rtorrent:0.15.2 #48

### DIFF
--- a/rtorrent/rtorrent.rc
+++ b/rtorrent/rtorrent.rc
@@ -24,6 +24,11 @@ execute.throw = sh, -c, (cat,\
     "\"",(cfg.watch),"/load\" ",\
     "\"",(cfg.watch),"/start\" ")
 
+## Needed for compatibility between Flood and upstream rTorrent:0.15.2
+method.redirect=load.throw,load.normal
+method.redirect=load.start_throw,load.start
+method.insert=d.down.sequential,value|const,0
+method.insert=d.down.sequential.set,value|const,0
 
 ## Tracker-less torrent and UDP tracker support
 ## (conservative settings for 'private' trackers, change for 'public')


### PR DESCRIPTION
This PR fixes the compatibility issues between [Flood](https://github.com/jesec/flood) and [rTorrent](https://github.com/rakshasa/rtorrent) as mentioned in #48 

The fix only applies to newly generated copies of rtorrent.rc, which are typically created the first time the Docker container is started. To apply this fix, you can either delete the existing rtorrent.rc file to allow the image to generate a new configuration with the fix included or manually edit the rtorrent.rc file and add the following lines:

```ini
method.redirect=load.throw,load.normal
method.redirect=load.start_throw,load.start
method.insert=d.down.sequential,value|const,0
method.insert=d.down.sequential.set,value|const,0
```